### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/image-uploader.js
+++ b/lib/image-uploader.js
@@ -1,5 +1,5 @@
 const moment = require('moment')
-const uuid = require('node-uuid')
+const uuid = require('uuid')
 const info = require('../package.json')
 
 const debug = require('debug')(`${info.name}:imageUploader`)

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "meow": "^3.6.0",
     "moment": "^2.10.6",
     "node-horseman": "^2.8.2",
-    "node-uuid": "^1.4.7",
     "object-assign": "^4.0.1",
     "phantomjs": "*",
     "prettyjson": "^1.1.3",
@@ -35,6 +34,7 @@
     "request": "^2.67.0",
     "stream-buffers": "^3.0.0",
     "update-notifier": "^0.6.0",
+    "uuid": "^3.0.0",
     "validator": "^4.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.